### PR TITLE
Fix for deprecation RDF::URI#to_hash

### DIFF
--- a/lib/bib_card/crawler.rb
+++ b/lib/bib_card/crawler.rb
@@ -2,7 +2,7 @@ module BibCard
   class Crawler
     
     def initialize(uri, repository)
-      @subject = RDF::URI.new(uri)
+      @subject = RDF::URI(uri)
       @repository = repository
     end
   


### PR DESCRIPTION
Per Issue #341 on RDF Issues

- https://github.com/ruby-rdf/rdf/issues/341
- Use RDF::URI(uri) instead ofRDF::URI.new(uri)